### PR TITLE
Support non-interactive execution (e.g. GitHub actions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ backport <source-ref> <target-branch> [-c | --continue] [-l | --local] [-ni | --
 Options:
   -l, --local            Skip pushing the branch and creating the PR
   -c, --continue         Continue backporting after fixing cherry-pick conflict
-  -ni, --non-interactive Headlessly creates the PR automatically, without previewing in web browser"
+  -ni, --non-interactive Headlessly creates the PR automatically, without previewing in web browser
 
 What does it do:
    'backport master upstream/5.2.z' - will perform the following actions:

--- a/README.md
+++ b/README.md
@@ -5,11 +5,12 @@ Then it pushes the newly created branch and creates a new PR.
 
 ```
 Usage: 
-backport <source-ref> <target-branch> [-c | --continue] [-l | --local]
+backport <source-ref> <target-branch> [-c | --continue] [-l | --local] [-ni | --non-interactive]
 
 Options:
-  -l, --local    Skip pushing the branch and creating the PR
-  -c, --continue Continue backporting after fixing cherry-pick conflict
+  -l, --local            Skip pushing the branch and creating the PR
+  -c, --continue         Continue backporting after fixing cherry-pick conflict
+  -ni, --non-interactive Headlessly creates the PR automatically, without previewing in web browser"
 
 What does it do:
    'backport master upstream/5.2.z' - will perform the following actions:

--- a/backport
+++ b/backport
@@ -50,7 +50,7 @@ get_opts() {
       shift
       ;;
     -ni | --non-interactive)
-      CI=true
+      NON_INTERACTIVE=true
       shift
       ;;
     -h | --help)
@@ -139,7 +139,7 @@ if [ "$LOCAL" = "yes" ]; then
   exit 0
 fi
 
-if [ "$CI" = "true" ]; then
+if [ "$NON_INTERACTIVE" = "true" ]; then
   log_info "Pushing $BRANCH_NAME to origin"
   # https://github.com/cli/cli/issues/1718#issuecomment-748292216
   git pull
@@ -150,7 +150,7 @@ ORIGINAL_PR_URL="https://github.com/${REPO_UPSTREAM}/pull/${ORIGINAL_PR_NUMBER:-
 BASE_BRANCH="$SUFFIX"
 PR_BODY=$(\cat .github/pull_request_template.md 2>/dev/null || true)
 if [ -n "$ORIGINAL_PR_NUMBER" ]; then
-  if [ "$CI" = "true" ]; then
+  if [ "$NON_INTERACTIVE" = "true" ]; then
     #  --reviewer flag doesn't work with --web
     REVIEWERS=$(gh api repos/"$REPO_UPSTREAM"/pulls/"$ORIGINAL_PR_NUMBER"/reviews | jq '.[] | select(.state == "APPROVED") | .user.login' | jq -c -r -s '. | unique | join(",")')
     if [ -n "$REVIEWERS" ]; then
@@ -168,4 +168,4 @@ log_info "Creating new PR..."
 gh pr create --base "$BASE_BRANCH" --title "$NEW_COMMIT_MSG" \
   --body "Backport of $ORIGINAL_PR_URL$(echo -e "\n\n")$PR_BODY" \
   --assignee "${GITHUB_ACTOR:-@me}" $REVIEWERS_ARG "${LABELS_ARG[@]}" --milestone "$SUFFIX" \
-  $( [ "$CI" != true ] && echo "--web" )
+  $( [ "$NON_INTERACTIVE" != true ] && echo "--web" )

--- a/backport
+++ b/backport
@@ -12,7 +12,7 @@ function usage() {
   echo "Options:"
   echo "  -l,  --local           Skip pushing the branch and creating the PR"
   echo "  -c,  --continue        Continue backporting after fixing cherry-pick conflict"
-  echo "  -ni, --non-interactive Continue backporting after fixing cherry-pick conflict"
+  echo "  -ni, --non-interactive Headlessly creates the PR automatically, without previewing in web browser"
   echo
   echo "What does it do:"
   echo "   '$(basename "$0") master upstream/5.2.z' - will perform the following actions:"

--- a/backport
+++ b/backport
@@ -7,11 +7,12 @@ function usage() {
   echo "Then it pushes the newly created branch and creates a new PR."
   echo
   echo "Usage: "
-  echo "$(basename "$0") <source-ref> <target-branch> [-c | --continue] [-l | --local]"
+  echo "$(basename "$0") <source-ref> <target-branch> [-c | --continue] [-l | --local] [-ni | --non-interactive]"
   echo
   echo "Options:"
-  echo "  -l, --local    Skip pushing the branch and creating the PR"
-  echo "  -c, --continue Continue backporting after fixing cherry-pick conflict"
+  echo "  -l,  --local           Skip pushing the branch and creating the PR"
+  echo "  -c,  --continue        Continue backporting after fixing cherry-pick conflict"
+  echo "  -ni, --non-interactive Continue backporting after fixing cherry-pick conflict"
   echo
   echo "What does it do:"
   echo "   '$(basename "$0") master upstream/5.2.z' - will perform the following actions:"
@@ -31,7 +32,7 @@ check_command() {
 check_command "gh" "https://cli.github.com/"
 check_command "jq" "https://jqlang.github.io/jq/download/"
 
-if [[ $# -lt 2 || $# -gt 4 ]]; then
+if [[ $# -lt 2 || $# -gt 5 ]]; then
   usage
   exit 1
 fi
@@ -46,6 +47,10 @@ get_opts() {
       ;;
     -l | --local)
       LOCAL=yes
+      shift
+      ;;
+    -ni | --non-interactive)
+      CI=true
       shift
       ;;
     -h | --help)

--- a/backport
+++ b/backport
@@ -157,4 +157,4 @@ fi
 log_info "Creating new PR..."
 gh pr create --base "$BASE_BRANCH" --title "$NEW_COMMIT_MSG" \
   --body "Backport of $ORIGINAL_PR_URL$(echo -e "\n\n")$PR_BODY" \
-  --assignee "@me" $REVIEWERS_ARG "${LABELS_ARG[@]}" --milestone "$SUFFIX" --web
+  --assignee "@me" $REVIEWERS_ARG "${LABELS_ARG[@]}" --milestone "$SUFFIX"

--- a/backport
+++ b/backport
@@ -102,7 +102,6 @@ log_info "Backporting the last commit from $SOURCE onto $TARGET"
 COMMIT_MSG=$(git show -s --format='%s' "$SOURCE")
 ORIGINAL_PR_NUMBER=$(echo "$COMMIT_MSG" | grep -oP '#(\d+)' | tail -n1 | cut -c2-)
 NEW_COMMIT_MSG="$( echo "${COMMIT_MSG// \(\#$ORIGINAL_PR_NUMBER\)}" | sed -r 's/ \[.+\]//g') [$SUFFIX]"
-# REPO_ORIGIN_OWNER="$(git remote get-url origin | cut -d: -f2 | cut -d/ -f1)"
 UPSTREAM_URL="$(git remote get-url upstream)"
 if [[ $UPSTREAM_URL == http* ]]; then
   REPO_UPSTREAM="$(echo $UPSTREAM_URL | awk -F'/' '{print $4"/"$5}' | cut -d. -f1)"

--- a/backport
+++ b/backport
@@ -102,7 +102,7 @@ log_info "Backporting the last commit from $SOURCE onto $TARGET"
 COMMIT_MSG=$(git show -s --format='%s' "$SOURCE")
 ORIGINAL_PR_NUMBER=$(echo "$COMMIT_MSG" | grep -oP '#(\d+)' | tail -n1 | cut -c2-)
 NEW_COMMIT_MSG="$( echo "${COMMIT_MSG// \(\#$ORIGINAL_PR_NUMBER\)}" | sed -r 's/ \[.+\]//g') [$SUFFIX]"
-REPO_ORIGIN_OWNER="$(git remote get-url origin | cut -d: -f2 | cut -d/ -f1)"
+# REPO_ORIGIN_OWNER="$(git remote get-url origin | cut -d: -f2 | cut -d/ -f1)"
 UPSTREAM_URL="$(git remote get-url upstream)"
 if [[ $UPSTREAM_URL == http* ]]; then
   REPO_UPSTREAM="$(echo $UPSTREAM_URL | awk -F'/' '{print $4"/"$5}' | cut -d. -f1)"
@@ -135,18 +135,24 @@ if [ "$LOCAL" = "yes" ]; then
   exit 0
 fi
 
-#log_info "Pushing $BRANCH_NAME to origin"
-#git push origin
+if [ "$CI" = "true" ]; then
+  log_info "Pushing $BRANCH_NAME to origin"
+  # https://github.com/cli/cli/issues/1718#issuecomment-748292216
+  git pull
+  git push -u origin HEAD
+fi
 
 ORIGINAL_PR_URL="https://github.com/${REPO_UPSTREAM}/pull/${ORIGINAL_PR_NUMBER:-<pr-number>}"
 BASE_BRANCH="$SUFFIX"
 PR_BODY=$(\cat .github/pull_request_template.md 2>/dev/null || true)
 if [ -n "$ORIGINAL_PR_NUMBER" ]; then
-#  --reviewer flag doesn't work with --web
-#  REVIEWERS=$(gh api repos/$REPO_UPSTREAM/pulls/$ORIGINAL_PR_NUMBER/reviews | jq '.[] | select(.state == "APPROVED") | .user.login' | jq -c -r -s '. | unique | join(",")')
-#  if [ -n "$REVIEWERS" ]; then
-#    REVIEWERS_ARG="--reviewer $REVIEWERS"
-#  fi
+  if [ "$CI" = "true" ]; then
+    #  --reviewer flag doesn't work with --web
+    REVIEWERS=$(gh api repos/"$REPO_UPSTREAM"/pulls/"$ORIGINAL_PR_NUMBER"/reviews | jq '.[] | select(.state == "APPROVED") | .user.login' | jq -c -r -s '. | unique | join(",")')
+    if [ -n "$REVIEWERS" ]; then
+      REVIEWERS_ARG="--reviewer $REVIEWERS"
+    fi
+  fi
   PR_BODY=$(gh api repos/$REPO_UPSTREAM/pulls/$ORIGINAL_PR_NUMBER | jq -r '"\n\n" + .body')
 
   LABELS=$(gh api repos/$REPO_UPSTREAM/pulls/$ORIGINAL_PR_NUMBER | jq '.labels[].name' | jq -c -r -s '. | join(",")')
@@ -157,4 +163,5 @@ fi
 log_info "Creating new PR..."
 gh pr create --base "$BASE_BRANCH" --title "$NEW_COMMIT_MSG" \
   --body "Backport of $ORIGINAL_PR_URL$(echo -e "\n\n")$PR_BODY" \
-  --assignee "@me" $REVIEWERS_ARG "${LABELS_ARG[@]}" --milestone "$SUFFIX"
+  --assignee "${GITHUB_ACTOR:-@me}" $REVIEWERS_ARG "${LABELS_ARG[@]}" --milestone "$SUFFIX" \
+  $( [ "$CI" != true ] && echo "--web" )


### PR DESCRIPTION
This script cannot be run headlessly because:
- the `gh` cli works differently in headless environments (can't prompt for queries so just crashes)
- pull requests can't be created via the browser
- when run from a GitHub action, the executing user may not be the best assignee

Change to support both headless & interactive executions.