### PR TITLE
Fix running script from other directory

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -14,4 +14,4 @@ jobs:
     runs-on: ${{matrix.runs-on}}
     steps:
       - uses: actions/checkout@v4
-      - run: ./backport.functions_tests
+      - run: ./test_scripts

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+assert.sh

--- a/backport
+++ b/backport
@@ -22,8 +22,10 @@ function usage() {
   echo "    - create a PR from the new branch to 5.2.z branch with body and labels from the original PR (if found)"
 }
 
+SCRIPT_DIR=$(readlink -f "$0")
+SCRIPT_DIR="$(dirname "${SCRIPT_DIR}")"
 # shellcheck source=/dev/null
-. backport.functions
+. "${SCRIPT_DIR}"/backport.functions
 
 check_command() {
   if ! [ -x "$(command -v "$1")" ]; then

--- a/backport
+++ b/backport
@@ -30,7 +30,7 @@ SCRIPT_DIR="$(dirname "${SCRIPT_DIR}")"
 check_command() {
   if ! [ -x "$(command -v "$1")" ]; then
     echo "Error: '$1' tool required - $2"
-    exit 2
+    exit 1
   fi
 }
 
@@ -39,7 +39,7 @@ check_command "jq" "https://jqlang.github.io/jq/download/"
 
 if [[ $# -lt 2 || $# -gt 5 ]]; then
   usage
-  exit 1
+  exit 2
 fi
 
 get_opts() {

--- a/backport.functions_tests
+++ b/backport.functions_tests
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 set -eu
-SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+SCRIPT_DIR=$(readlink -f "$0")
+SCRIPT_DIR="$(dirname "${SCRIPT_DIR}")"
 
 # Source the latest version of assert.sh unit testing library and include in current shell
 curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh --output assert.sh
@@ -11,7 +12,8 @@ curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.
 # . <(echo "${assert_script_content}")
 # But this doesn't work on the MacOS GitHub runner (but does on MacOS locally)
 . assert.sh
-. "$SCRIPT_DIR"/backport.functions
+# shellcheck source=/dev/null
+. "${SCRIPT_DIR}"/backport.functions
 
 TESTS_RESULT=0
 

--- a/backport_tests
+++ b/backport_tests
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -eu
+SCRIPT_DIR=$(readlink -f "$0")
+SCRIPT_DIR="$(dirname "${SCRIPT_DIR}")"
+
+# Source the latest version of assert.sh unit testing library and include in current shell
+curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh --output assert.sh
+
+# shellcheck source=/dev/null
+# You _should_ be able to avoid a temporary file with something like
+# . <(echo "${assert_script_content}")
+# But this doesn't work on the MacOS GitHub runner (but does on MacOS locally)
+. assert.sh
+# shellcheck source=/dev/null
+# . "${SCRIPT_DIR}"/backport
+
+TESTS_RESULT=0
+
+function test_get_exit_code {
+  local expected_exit_code=$1
+  local backport_arguments=( "${@:2:99}" )
+  local actual_exit_code
+  ("${SCRIPT_DIR}"/backport "${backport_arguments[@]:-}") && true
+  actual_exit_code=$?
+  local msg="Expected exit code with arguments \"${backport_arguments[*]:-}\" should be equal to \"${expected_exit_code}\""
+  assert_eq "${expected_exit_code}" "${actual_exit_code}" "${msg}" && log_success "${msg}" || TESTS_RESULT=$?
+}
+
+log_header "Tests exit code"
+# https://github.com/hazelcast/backport/issues/10
+# Find location of a temp directory, where script is _unlikely_ to exist
+TMPDIR=$(mktemp)
+TMPDIR="$(dirname "${TMPDIR}")"
+(cd "${TMPDIR}"; test_get_exit_code 2)
+
+assert_eq 0 "${TESTS_RESULT}" "All tests should pass"

--- a/test_scripts
+++ b/test_scripts
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+function findScriptDir() {
+  CURRENT=$PWD
+
+  DIR=$(dirname "$0")
+  cd "$DIR" || exit
+  TARGET_FILE=$(basename "$0")
+
+  # Iterate down a (possible) chain of symlinks
+  while [ -L "$TARGET_FILE" ]
+  do
+      TARGET_FILE=$(readlink "$TARGET_FILE")
+      DIR=$(dirname "$TARGET_FILE")
+      cd "$DIR" || exit
+      TARGET_FILE=$(basename "$TARGET_FILE")
+  done
+
+  SCRIPT_DIR=$(pwd -P)
+  # Restore current directory
+  cd "$CURRENT" || exit
+}
+
+findScriptDir
+
+find "$SCRIPT_DIR" -name "*_tests" -print0 | xargs -0 -n1 bash

--- a/test_scripts
+++ b/test_scripts
@@ -1,26 +1,6 @@
 #!/usr/bin/env bash
 
-function findScriptDir() {
-  CURRENT=$PWD
-
-  DIR=$(dirname "$0")
-  cd "$DIR" || exit
-  TARGET_FILE=$(basename "$0")
-
-  # Iterate down a (possible) chain of symlinks
-  while [ -L "$TARGET_FILE" ]
-  do
-      TARGET_FILE=$(readlink "$TARGET_FILE")
-      DIR=$(dirname "$TARGET_FILE")
-      cd "$DIR" || exit
-      TARGET_FILE=$(basename "$TARGET_FILE")
-  done
-
-  SCRIPT_DIR=$(pwd -P)
-  # Restore current directory
-  cd "$CURRENT" || exit
-}
-
-findScriptDir
+SCRIPT_DIR=$(readlink -f "$0")
+SCRIPT_DIR="$(dirname "${SCRIPT_DIR}")"
 
 find "$SCRIPT_DIR" -name "*_tests" -print0 | xargs -0 -n1 bash


### PR DESCRIPTION
The `source` assumed that the `backport.functions` script would always be in the _current_ directory, but as this script's current directory is expected to be a `git` repo, this is not correct.

Changes:
- use same dynamic script location resolution as used in test
- resolve some Shellcheck warnings in that resolution
- updates exit codes to [better follow conventions](https://stackoverflow.com/a/40484670)
- added unit test

Fixes: https://github.com/hazelcast/backport/issues/10