### PR TITLE
Remove `JQ` command requirement

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -3,6 +3,9 @@ name: Test PR
 on:
   pull_request:
 
+env:
+  GH_TOKEN: ${{ github.token }}
+
 jobs:
   test:
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+assert.sh

--- a/backport
+++ b/backport
@@ -33,7 +33,6 @@ check_command() {
 }
 
 check_command "gh" "https://cli.github.com/"
-check_command "jq" "https://jqlang.github.io/jq/download/"
 
 if [[ $# -lt 2 || $# -gt 5 ]]; then
   usage
@@ -155,14 +154,14 @@ PR_BODY=$(\cat .github/pull_request_template.md 2>/dev/null || true)
 if [ -n "$ORIGINAL_PR_NUMBER" ]; then
   if [ "$NON_INTERACTIVE" = "true" ]; then
     #  --reviewer flag doesn't work with --web
-    REVIEWERS=$(gh api repos/"$REPO_UPSTREAM"/pulls/"$ORIGINAL_PR_NUMBER"/reviews | jq '.[] | select(.state == "APPROVED") | .user.login' | jq -c -r -s '. | unique | join(",")')
+    REVIEWERS=$(get_pr_reviewers "${REPO_UPSTREAM}" "${ORIGINAL_PR_NUMBER}")
     if [ -n "$REVIEWERS" ]; then
       REVIEWERS_ARG="--reviewer $REVIEWERS"
     fi
   fi
-  PR_BODY=$(gh api repos/$REPO_UPSTREAM/pulls/$ORIGINAL_PR_NUMBER | jq -r '"\n\n" + .body')
+  PR_BODY=$(gh api repos/$REPO_UPSTREAM/pulls/$ORIGINAL_PR_NUMBER --jq '"\n\n" + .body')
 
-  LABELS=$(gh api repos/$REPO_UPSTREAM/pulls/$ORIGINAL_PR_NUMBER | jq '.labels[].name' | jq -c -r -s '. | join(",")')
+  LABELS=$(get_pr_labels "${REPO_UPSTREAM}" "${ORIGINAL_PR_NUMBER}")
   if [ -n "$LABELS" ]; then
     LABELS_ARG=(--label "$LABELS")
   fi

--- a/backport.functions
+++ b/backport.functions
@@ -3,7 +3,21 @@
 set -e
 
 function get_pr_number() {
-
   local commit_msg=$1
+
   echo "$commit_msg" | grep --extended-regexp --only-matching '#[0-9]+' | tail -n1 | cut -c2-
+}
+
+function get_pr_reviewers() {
+  local repo_upstream=$1
+  local pr_number=$2
+
+  gh api repos/"${repo_upstream}"/pulls/"${pr_number}"/reviews --jq '[.[] | select(.state == "APPROVED") | .user.login] | unique | join(",")'
+}
+
+function get_pr_labels() {
+  local repo_upstream=$1
+  local pr_number=$2
+
+  gh api repos/"${repo_upstream}"/pulls/"${pr_number}" --jq '[.labels[].name] | join(",")'
 }

--- a/backport.functions_tests
+++ b/backport.functions_tests
@@ -23,8 +23,32 @@ function test_get_pr_number {
   assert_eq "$expected_pr_number" "$actual_pr_number" "$MSG" && log_success "$MSG" || TESTS_RESULT=$?
 }
 
+function test_get_pr_reviewers {
+  local repo_upstream=$1
+  local pr_number=$2
+  local expected_reviewers=$3
+  local actual_reviewers=$(get_pr_reviewers "$repo_upstream" "$pr_number")
+  local MSG="Expected reviewers extracted from \"$repo_upstream/pull/$pr_number\" should be equal to \"$expected_reviewers\""
+  assert_eq "$expected_reviewers" "$actual_reviewers" "$MSG" && log_success "$MSG" || TESTS_RESULT=$?
+}
+
+function test_get_pr_labels {
+  local repo_upstream=$1
+  local pr_number=$2
+  local expected_labels=$3
+  local actual_labels=$(get_pr_labels "$repo_upstream" "$pr_number")
+  local MSG="Expected labels extracted from \"$repo_upstream/pull/$pr_number\" should be equal to \"$actual_labels\""
+  assert_eq "$expected_labels" "$actual_labels" "$MSG" && log_success "$MSG" || TESTS_RESULT=$?
+}
+
 log_header "Tests for get_pr_number"
 test_get_pr_number 'Fix private test repository access [DI-236] (#221)' '221'
 test_get_pr_number 'Fix private test repository access [DI-236] (#221) (#222)' '222'
+
+log_header "Tests for get_pr_reviewers"
+test_get_pr_reviewers 'hazelcast/backport' '1' 'ldziedziul'
+
+log_header "Tests for get_pr_labels"
+test_get_pr_labels 'hazelcast/backport' '1' 'enhancement'
 
 assert_eq 0 "$TESTS_RESULT" "All tests should pass"


### PR DESCRIPTION
`gh` includes `jq` querying functionality.
This means the queries can be rewritten to drop the requirement for a `jq` pre-requisite.

This also _potentially_ makes mocking easier in future by reducing the number of dependencies (...to 1...).