### PR TITLE
Support backporting to branches with `/` in name [DOC-268]

### DIFF
--- a/backport
+++ b/backport
@@ -104,7 +104,7 @@ SOURCE=$1
 TARGET=$2
 
 # SUFFIX can be 5.2.3, 5.1.z, etc
-SUFFIX="${TARGET#*/}"
+SUFFIX=$(get_branch_from_ref "${TARGET}")
 
 log_info "Backporting the last commit from $SOURCE onto $TARGET"
 

--- a/backport
+++ b/backport
@@ -104,7 +104,7 @@ SOURCE=$1
 TARGET=$2
 
 # SUFFIX can be 5.2.3, 5.1.z, etc
-SUFFIX="${TARGET##*/}"
+SUFFIX="${TARGET#*/}"
 
 log_info "Backporting the last commit from $SOURCE onto $TARGET"
 

--- a/backport.functions
+++ b/backport.functions
@@ -21,3 +21,10 @@ function get_pr_labels() {
 
   gh api repos/"${repo_upstream}"/pulls/"${pr_number}" --jq '[.labels[].name] | join(",")'
 }
+
+# upstream/5.2.z -> 5.2z
+function get_branch_from_ref() {
+  local ref=$1
+
+  echo "${ref#*/}"
+}

--- a/backport.functions_tests
+++ b/backport.functions_tests
@@ -43,6 +43,14 @@ function test_get_pr_labels {
   assert_eq "$expected_labels" "$actual_labels" "$MSG" && log_success "$MSG" || TESTS_RESULT=$?
 }
 
+function test_get_branch_from_ref {
+  local ref=$1
+  local expected_branch=$2
+  local actual_branch=$(get_branch_from_ref "$ref")
+  local MSG="Expected branch extracted from \"$ref\" should be equal to \"$actual_branch\""
+  assert_eq "$expected_branch" "$actual_branch" "$MSG" && log_success "$MSG" || TESTS_RESULT=$?
+}
+
 log_header "Tests for get_pr_number"
 test_get_pr_number 'Fix private test repository access [DI-236] (#221)' '221'
 test_get_pr_number 'Fix private test repository access [DI-236] (#221) (#222)' '222'
@@ -52,5 +60,9 @@ test_get_pr_reviewers 'hazelcast/backport' '1' 'ldziedziul'
 
 log_header "Tests for get_pr_labels"
 test_get_pr_labels 'hazelcast/backport' '1' 'enhancement'
+
+log_header "Tests for get_branch_from_ref"
+test_get_branch_from_ref 'upstream/5.2.z' '5.2.z'
+test_get_branch_from_ref 'upstream/v/5.2' 'v/5.2'
 
 assert_eq 0 "$TESTS_RESULT" "All tests should pass"


### PR DESCRIPTION
When backporting to a branch like `v/5.5`, the `v/` prefix is erroneously considered part of the `remote` name and discarded.

Fixes: [DOC-268](https://hazelcast.atlassian.net/browse/DOC-268)

[DOC-268]: https://hazelcast.atlassian.net/browse/DOC-268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ