### PR TITLE
Add `omit-labels` functionality [DOC-268]

### DIFF
--- a/.github/actions/backport/action.yml
+++ b/.github/actions/backport/action.yml
@@ -11,6 +11,9 @@ inputs:
   REF_TO_BACKPORT:
     description: The reference of the commit to be backported
     required: true
+  BACKPORT_OPTIONS:
+    description: Additional options to pass through to the tool
+    required: false
 
 env:
   # Not possible to set this as a default
@@ -54,7 +57,8 @@ runs:
         ${GITHUB_ACTION_PATH}/../../../backport \
           "${{ inputs.REF_TO_BACKPORT }}" \
           "${backport_target_branch}" \
-          --non-interactive
+          --non-interactive \
+          ${{ inputs.BACKPORT_OPTIONS }}
       env:
         GH_TOKEN: ${{ github.token }}
 

--- a/backport
+++ b/backport
@@ -13,6 +13,7 @@ function usage() {
   echo "  -l,  --local           Skip pushing the branch and creating the PR"
   echo "  -c,  --continue        Continue backporting after fixing cherry-pick conflict"
   echo "  -ni, --non-interactive Headlessly creates the PR automatically, without previewing in web browser"
+  echo "  -ol, --omit-labels     Omit copying labels to backport PR"
   echo
   echo "What does it do:"
   echo "   '$(basename "$0") master upstream/5.2.z' - will perform the following actions:"
@@ -55,6 +56,10 @@ get_opts() {
       ;;
     -ni | --non-interactive)
       NON_INTERACTIVE=true
+      shift
+      ;;
+    -ol | --omit-labels)
+      OMIT_LABELS=true
       shift
       ;;
     -h | --help)
@@ -163,11 +168,14 @@ if [ -n "$ORIGINAL_PR_NUMBER" ]; then
   fi
   PR_BODY=$(gh api repos/$REPO_UPSTREAM/pulls/$ORIGINAL_PR_NUMBER --jq '"\n\n" + .body')
 
-  LABELS=$(get_pr_labels "${REPO_UPSTREAM}" "${ORIGINAL_PR_NUMBER}")
-  if [ -n "$LABELS" ]; then
-    LABELS_ARG=(--label "$LABELS")
+  if [[ "${OMIT_LABELS}" != "true" ]]; then
+    LABELS=$(get_pr_labels "${REPO_UPSTREAM}" "${ORIGINAL_PR_NUMBER}")
+    if [[ -n "${LABELS}" ]]; then
+      LABELS_ARG=(--label "${LABELS}")
+    fi
   fi
 fi
+
 log_info "Creating new PR..."
 gh pr create --base "$BASE_BRANCH" --title "$NEW_COMMIT_MSG" \
   --body "Backport of $ORIGINAL_PR_URL$(echo -e "\n\n")$PR_BODY" \


### PR DESCRIPTION
When backports are triggered via PR labels, copying the labels to the backport PRs can cause an unexpected cascade.

E.G.:
- a PR is labelled to backport to multiple branches
- an action performs these actions _in parallel_
- the backported, labelled PRs are detected
- more backporting is performed
- etc

Instead it would be easier to _optionally_ omit copying labels to backported PRs.

Fixes: [DOC-268](https://hazelcast.atlassian.net/browse/DOC-268)

[DOC-268]: https://hazelcast.atlassian.net/browse/DOC-268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ