### PR TITLE
Only apply milestone to PR if it exists [DOC-268]

### DIFF
--- a/backport
+++ b/backport
@@ -169,7 +169,12 @@ if [ -n "$ORIGINAL_PR_NUMBER" ]; then
   fi
 fi
 log_info "Creating new PR..."
-gh pr create --base "$BASE_BRANCH" --title "$NEW_COMMIT_MSG" \
-  --body "Backport of $ORIGINAL_PR_URL$(echo -e "\n\n")$PR_BODY" \
-  --assignee "${GITHUB_ACTOR:-@me}" $REVIEWERS_ARG "${LABELS_ARG[@]}" --milestone "$SUFFIX" \
-  $( [ "$NON_INTERACTIVE" != true ] && echo "--web" )
+gh pr create \
+  --base "${BASE_BRANCH}" \
+  --title "${NEW_COMMIT_MSG}" \
+  --body "Backport of ${ORIGINAL_PR_URL}$(echo -e "\n\n")${PR_BODY}" \
+  --assignee "${GITHUB_ACTOR:-@me}" \
+  ${REVIEWERS_ARG} \
+  "${LABELS_ARG[@]}" \
+  $( [ "$(check_if_milestone_in_repo ${REPO_UPSTREAM} ${SUFFIX})" == "true" ] && echo "--milestone ${SUFFIX}" ) \
+  $( [ "${NON_INTERACTIVE}" != true ] && echo "--web" )

--- a/backport.functions
+++ b/backport.functions
@@ -12,12 +12,25 @@ function get_pr_reviewers() {
   local repo_upstream=$1
   local pr_number=$2
 
-  gh api repos/"${repo_upstream}"/pulls/"${pr_number}"/reviews --jq '[.[] | select(.state == "APPROVED") | .user.login] | unique | join(",")'
+  gh api "repos/${repo_upstream}/pulls/${pr_number}/reviews" --jq '[.[] | select(.state == "APPROVED") | .user.login] | unique | join(",")'
 }
 
 function get_pr_labels() {
   local repo_upstream=$1
   local pr_number=$2
 
-  gh api repos/"${repo_upstream}"/pulls/"${pr_number}" --jq '[.labels[].name] | join(",")'
+  gh api "repos/${repo_upstream}/pulls/${pr_number}" --jq '[.labels[].name] | join(",")'
+}
+
+function check_if_milestone_in_repo() {
+  local repo_upstream=$1
+  local milestone=$2
+
+  response=$(gh api "repos/${repo_upstream}/milestones?state=all" --paginate --jq ".[] | select(.title == \"${milestone}\")")
+
+  if [[ -n "${response}" ]]; then
+    echo true
+  else
+    echo false
+  fi
 }

--- a/backport.functions_tests
+++ b/backport.functions_tests
@@ -43,6 +43,15 @@ function test_get_pr_labels {
   assert_eq "$expected_labels" "$actual_labels" "$MSG" && log_success "$MSG" || TESTS_RESULT=$?
 }
 
+function test_check_if_milestone_in_repo {
+  local repo_upstream=$1
+  local milestone=$2
+  local expected_output=$3
+  local actual_output=$(check_if_milestone_in_repo "$repo_upstream" "$milestone")
+  local MSG="Queried \"$repo_upstream\" for milestone \"$milestone\", expecting \"$expected_output\""
+  assert_eq "$expected_output" "$actual_output" "$MSG" && log_success "$MSG" || TESTS_RESULT=$?
+}
+
 log_header "Tests for get_pr_number"
 test_get_pr_number 'Fix private test repository access [DI-236] (#221)' '221'
 test_get_pr_number 'Fix private test repository access [DI-236] (#221) (#222)' '222'
@@ -52,5 +61,10 @@ test_get_pr_reviewers 'hazelcast/backport' '1' 'ldziedziul'
 
 log_header "Tests for get_pr_labels"
 test_get_pr_labels 'hazelcast/backport' '1' 'enhancement'
+
+log_header "Tests for check_if_milestone_in_repo"
+# https://github.com/hazelcast/hazelcast/milestones
+test_check_if_milestone_in_repo 'hazelcast/hazelcast' '2.1' 'true'
+test_check_if_milestone_in_repo 'hazelcast/hazelcast' 'this-milestone-does-not-exist' 'false'
 
 assert_eq 0 "$TESTS_RESULT" "All tests should pass"


### PR DESCRIPTION
If a milestone doesn't exist, [an error is thrown when doing a backport](https://github.com/JackPGreen2/hz-docs/actions/runs/11963090837/job/33352851231#step:7:96).

Not all repositories use milestones - instead it should only be applied to the PR, _if it exists_.

Fixes: [DOC-268](https://hazelcast.atlassian.net/browse/DOC-268)

[DOC-268]: https://hazelcast.atlassian.net/browse/DOC-268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ