### PR TITLE
Create centralised `backport` workflow

### DIFF
--- a/.github/actions/backport/action.yml
+++ b/.github/actions/backport/action.yml
@@ -11,7 +11,7 @@ inputs:
   TARGET_BRANCH:
     description: The branch in the repository to backport changes into
     required: true
-  COMMIT_SHA:
+  REF_TO_BACKPORT:
     description: The reference of the commit to be backported
     required: true
   BACKPORT_OPTIONS:
@@ -46,10 +46,10 @@ runs:
         git fetch --all
 
         backport_target_branch=upstream/"${{ inputs.TARGET_BRANCH }}"
-        echo "::debug::Running backport script to backport "${{ inputs.COMMIT_SHA }}" into \"${backport_target_branch}\""
+        echo "::debug::Running backport script to backport "${{ inputs.REF_TO_BACKPORT }}" into \"${backport_target_branch}\""
 
         ${GITHUB_WORKSPACE}/backport/backport \
-          "${{ inputs.COMMIT_SHA }}" \
+          "${{ inputs.REF_TO_BACKPORT }}" \
           "${backport_target_branch}" \
           --non-interactive \
           ${{ inputs.BACKPORT_OPTIONS }}

--- a/.github/actions/backport/action.yml
+++ b/.github/actions/backport/action.yml
@@ -23,6 +23,23 @@ env:
 runs:
   using: composite
   steps:
+    - name: Assert branch exists
+      id: assert-branch-exists
+      shell: ${{ env.shell }}
+      run: |
+        if git ls-remote --exit-code --heads origin "${{ inputs.TARGET_BRANCH }}"; then
+          echo "::debug::Branch ${{ inputs.TARGET_BRANCH }} exists"
+        else
+          echo "::error::Branch ${{ inputs.TARGET_BRANCH }} does not exist"
+          gh pr comment "${{ github.event.pull_request.number }}" \
+            --repo ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} \
+            --body "❌ The backport branch \`${{ inputs.TARGET_BRANCH }}\` doesn't exist."
+          echo "failure-already-reported=true" >> ${GITHUB_OUTPUT}
+          exit 1
+        fi
+      env:
+        GH_TOKEN: ${{ github.token }}
+
     - name: Backport
       shell: ${{ env.shell }}
       run: |
@@ -47,11 +64,11 @@ runs:
 
     - name: Report errors
       shell: ${{ env.shell }}
-      if: failure()
+      if: failure() && steps.assert-branch-exists.outputs.failure-already-reported != 'true'
       run: |
         echo ":error::Error running action"
         echo "::group::Troubleshooting Information:"
-        echo "- Repositories' GitHub action configuration - $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/settings/actions"
+        echo "- Repositories' GitHub action configuration - ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/settings/actions"
         echo "- Action does not run when triggered from a forked repo's PR?"
         echo "    Enable \"Run workflows from fork pull requests\""
         echo "- Backport fails with \"GraphQL: GitHub Actions is not permitted to create or approve pull requests (createPullRequest)\"?"
@@ -63,6 +80,8 @@ runs:
         echo "        * Enable \"Send write tokens to workflows from fork pull requests\""
         echo "        * Use a different \"GITHUB_TOKEN\" with appropriate permissions"
         echo "::endgroup::"
-        gh pr comment "${{ github.event.pull_request.number }}" --repo $GITHUB_SERVER_URL/$GITHUB_REPOSITORY --body "❌ [Failed to backport]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID), change must be manually backported."
+        gh pr comment "${{ github.event.pull_request.number }}" \
+          --repo ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} \
+          --body "❌ [Failed to backport](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}), change must be manually backported."
       env:
         GH_TOKEN: ${{ github.token }}

--- a/.github/actions/backport/action.yml
+++ b/.github/actions/backport/action.yml
@@ -26,14 +26,7 @@ env:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v4
-      with:
-        repository: hazelcast/backport
-        # Hardcoded as composite actions don't support env vars properly
-        # https://github.com/orgs/community/discussions/51280
-        path: backport
-
-    - name: Checkout maintenance branch and cherry-pick
+    - name: Backport
       shell: ${{ env.shell }}
       working-directory: ${{ inputs.REPO_LOCATION }}
       run: |
@@ -48,7 +41,7 @@ runs:
         backport_target_branch=upstream/"${{ inputs.TARGET_BRANCH }}"
         echo "::debug::Running backport script to backport "${{ inputs.REF_TO_BACKPORT }}" into \"${backport_target_branch}\""
 
-        ${GITHUB_WORKSPACE}/backport/backport \
+        ${GITHUB_ACTION_PATH}/../../../backport \
           "${{ inputs.REF_TO_BACKPORT }}" \
           "${backport_target_branch}" \
           --non-interactive \

--- a/.github/actions/backport/action.yml
+++ b/.github/actions/backport/action.yml
@@ -5,9 +5,6 @@ name: Backport
 inputs:
   GITHUB_TOKEN:
     required: true
-  REPO_LOCATION:
-    description: The location of the checked-out repository to work with
-    required: true
   TARGET_BRANCH:
     description: The branch in the repository to backport changes into
     required: true
@@ -28,7 +25,6 @@ runs:
   steps:
     - name: Backport
       shell: ${{ env.shell }}
-      working-directory: ${{ inputs.REPO_LOCATION }}
       run: |
         # Git metadata is required but not available out-of-the-box, inherit from the action
         git config user.name "${GITHUB_ACTOR}"

--- a/.github/actions/backport/action.yml
+++ b/.github/actions/backport/action.yml
@@ -1,0 +1,67 @@
+name: Backport
+
+inputs:
+  GITHUB_TOKEN:
+    required: true
+  REPO_LOCATION:
+    required: true
+  TARGET_BRANCH:
+    required: true
+  COMMIT_SHA:
+    required: true
+  BACKPORT_OPTIONS:
+
+env:
+  # Not possible to set this as a default
+  # https://github.com/orgs/community/discussions/46670
+  shell: bash
+  backport_location: backport
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v4
+      with:
+        repository: hazelcast/backport
+        path: ${{ env.backport_location }}
+
+    - name: Checkout maintenance branch and cherry-pick
+      shell: ${{ env.shell }}
+      working-directory: ${{ inputs.REPO_LOCATION }}
+      run: |
+        # Git metadata is required but not available out-of-the-box, inherit from the action
+        git config user.name "${GITHUB_ACTOR}"
+        git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+
+        # Add "upstream" remote as checkout action doesn't include by default
+        git remote add upstream "${{ github.event.repository.clone_url }}"
+        git fetch --all
+
+        backport_target_branch=upstream/"${{ inputs.TARGET_BRANCH }}"
+        echo "::debug::Running backport script to backport "${{ inputs.COMMIT_SHA }}" into \"${backport_target_branch}\""
+
+        ${GITHUB_WORKSPACE}/${backport_location}/backport \
+          "${{ inputs.COMMIT_SHA }}" \
+          "${backport_target_branch}" \
+          --non-interactive \
+          ${{ inputs.BACKPORT_OPTIONS }}
+      env:
+        GH_TOKEN: ${{ github.token }}
+
+    - name: Report errors
+      if: failure()
+      run: |
+        echo "Error running action"
+        echo "Troubleshooting Information"
+        echo "- Repositories' GitHub action configuration - $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/settings/actions"
+        echo "- Action does not run when triggered from a forked repo's PR?"
+        echo "    Enable \"Run workflows from fork pull requests\""
+        echo "- Backport fails with \"GraphQL: GitHub Actions is not permitted to create or approve pull requests (createPullRequest)\"?"
+        echo "    Either:"
+        echo "        * Enable \"Allow GitHub Actions to create and approve pull requests\""
+        echo "        * Use a different \"GITHUB_TOKEN\" with appropriate permissions"
+        echo "- \"GraphQL: Resource not accessible by integration (addComment)\"?"
+        echo "    Either:"
+        echo "        * Enable \"Send write tokens to workflows from fork pull requests\""
+        echo "        * Use a different \"GITHUB_TOKEN\" with appropriate permissions"
+        gh pr comment "${{ github.event.pull_request.number }}" --repo $GITHUB_SERVER_URL/$GITHUB_REPOSITORY --body "❌ [Failed to backport]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID), change must be manually backported."

--- a/.github/actions/backport/action.yml
+++ b/.github/actions/backport/action.yml
@@ -1,13 +1,18 @@
 name: Backport
 
+# A composite action that allows Backporting via GitHub Actions (e.g. to be driven based on labels etc)
+
 inputs:
   GITHUB_TOKEN:
     required: true
   REPO_LOCATION:
+    description: The location of the checked-out repository to work with
     required: true
   TARGET_BRANCH:
+    description: The branch in the repository to backport changes into
     required: true
   COMMIT_SHA:
+    description: The reference of the commit to be backported
     required: true
   BACKPORT_OPTIONS:
 

--- a/.github/actions/backport/action.yml
+++ b/.github/actions/backport/action.yml
@@ -15,6 +15,7 @@ inputs:
     description: The reference of the commit to be backported
     required: true
   BACKPORT_OPTIONS:
+    description: Additional options to pass through to the tool
     required: false
 
 env:

--- a/.github/actions/backport/action.yml
+++ b/.github/actions/backport/action.yml
@@ -11,9 +11,6 @@ inputs:
   REF_TO_BACKPORT:
     description: The reference of the commit to be backported
     required: true
-  BACKPORT_OPTIONS:
-    description: Additional options to pass through to the tool
-    required: false
 
 env:
   # Not possible to set this as a default
@@ -57,8 +54,7 @@ runs:
         ${GITHUB_ACTION_PATH}/../../../backport \
           "${{ inputs.REF_TO_BACKPORT }}" \
           "${backport_target_branch}" \
-          --non-interactive \
-          ${{ inputs.BACKPORT_OPTIONS }}
+          --non-interactive
       env:
         GH_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
To support `backport` being used in multiple GitHub Actions:
- https://github.com/hazelcast/hazelcast-mono/pull/3642
- https://github.com/hazelcast/hz-docs/pull/1396

A composite GitHub Action has been created to centralise it's usage, to make callers simpler.

Implementation is a sliced from `hazelcast-mono`, with some parameters now explicit inputs.

Tested via [dummy PR](https://github.com/JackPGreen2/hz-docs/pull/14) in [test repo](https://github.com/JackPGreen2/hz-docs) that [backported successfully](https://github.com/JackPGreen2/hz-docs/actions/runs/12029584772/job/33536129458) (via https://github.com/JackPGreen2/hz-docs/pull/26).