### PR TITLE
Ensure backport action uses correct GitHub token

### DIFF
--- a/.github/actions/backport/action.yml
+++ b/.github/actions/backport/action.yml
@@ -38,7 +38,7 @@ runs:
           exit 1
         fi
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ inputs.GITHUB_TOKEN }}
 
     - name: Backport
       shell: ${{ env.shell }}
@@ -60,7 +60,7 @@ runs:
           --non-interactive \
           ${{ inputs.BACKPORT_OPTIONS }}
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ inputs.GITHUB_TOKEN }}
 
     - name: Report errors
       shell: ${{ env.shell }}
@@ -84,4 +84,4 @@ runs:
           --repo ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} \
           --body "❌ [Failed to backport](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}), change must be manually backported."
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ inputs.GITHUB_TOKEN }}


### PR DESCRIPTION
Following https://github.com/hazelcast/backport/pull/17, [backport PRs are being raised by `github-actions`](https://github.com/hazelcast/hazelcast-mono/pull/3669), rather than using the specified `GH_TOKEN`.