### PR TITLE
Automerge backport PRs

### DIFF
--- a/.github/actions/backport/action.yml
+++ b/.github/actions/backport/action.yml
@@ -62,6 +62,31 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.GITHUB_TOKEN }}
 
+    - name: Get new PR number
+      shell: ${{ env.shell }}
+      run: |
+        # GitHub has no out-of-the-box way to get the PR number when the PR is raised - instead, use the most recently-raised PR
+        # https://stackoverflow.com/a/76124312
+        PR_NUMBER=$(gh pr list \
+          --state open \
+          --base ${{ inputs.TARGET_BRANCH }} \
+          --json number,createdAt \
+          --limit 1 \
+          --jq 'sort_by(.createdAt) | reverse | .[0].number')
+        echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
+
+    - name: Enable PR automerge
+      shell: ${{ env.shell }}
+      run: |
+        gh pr merge ${PR_NUMBER} --auto
+
+    - name: Report success
+      shell: ${{ env.shell }}
+      run: |
+        gh pr comment "${{ github.event.pull_request.number }}" \
+          --repo $GITHUB_SERVER_URL/$GITHUB_REPOSITORY \
+          --body "👍 Created ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER} to backport into [\`${{ inputs.TARGET_BRANCH }}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tree/${{ inputs.TARGET_BRANCH }})."
+
     - name: Report errors
       shell: ${{ env.shell }}
       if: failure() && steps.assert-branch-exists.outputs.failure-already-reported != 'true'

--- a/.github/actions/backport/action.yml
+++ b/.github/actions/backport/action.yml
@@ -76,7 +76,7 @@ runs:
       run: |
         gh pr comment "${{ github.event.pull_request.number }}" \
           --repo ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} \
-          --body "👍 Created $(gh pr view --json url  --jq .url) to backport into [\`${{ inputs.TARGET_BRANCH }}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tree/${{ inputs.TARGET_BRANCH }})."
+          --body "👍 Created $(gh pr view --json url --jq .url) to backport into [\`${{ inputs.TARGET_BRANCH }}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tree/${{ inputs.TARGET_BRANCH }})."
       env:
         GH_TOKEN: ${{ inputs.GITHUB_TOKEN }}
 

--- a/.github/actions/backport/action.yml
+++ b/.github/actions/backport/action.yml
@@ -74,11 +74,15 @@ runs:
           --limit 1 \
           --jq 'sort_by(.createdAt) | reverse | .[0].number')
         echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
+      env:
+        GH_TOKEN: ${{ inputs.GITHUB_TOKEN }}
 
     - name: Enable PR automerge
       shell: ${{ env.shell }}
       run: |
         gh pr merge ${PR_NUMBER} --auto
+      env:
+        GH_TOKEN: ${{ inputs.GITHUB_TOKEN }}
 
     - name: Report success
       shell: ${{ env.shell }}
@@ -86,6 +90,8 @@ runs:
         gh pr comment "${{ github.event.pull_request.number }}" \
           --repo $GITHUB_SERVER_URL/$GITHUB_REPOSITORY \
           --body "👍 Created ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER} to backport into [\`${{ inputs.TARGET_BRANCH }}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tree/${{ inputs.TARGET_BRANCH }})."
+      env:
+        GH_TOKEN: ${{ inputs.GITHUB_TOKEN }}
 
     - name: Report errors
       shell: ${{ env.shell }}

--- a/.github/actions/backport/action.yml
+++ b/.github/actions/backport/action.yml
@@ -91,7 +91,7 @@ runs:
       run: |
         gh pr comment "${{ github.event.pull_request.number }}" \
           --repo $GITHUB_SERVER_URL/$GITHUB_REPOSITORY \
-          --body "👍 Created ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER} to backport into [\`${{ inputs.TARGET_BRANCH }}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tree/${{ inputs.TARGET_BRANCH }})."
+          --body "👍 Created ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${PR_NUMBER} to backport into [\`${{ inputs.TARGET_BRANCH }}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tree/${{ inputs.TARGET_BRANCH }})."
       env:
         GH_TOKEN: ${{ inputs.GITHUB_TOKEN }}
 

--- a/.github/actions/backport/action.yml
+++ b/.github/actions/backport/action.yml
@@ -73,14 +73,16 @@ runs:
           --json number,createdAt \
           --limit 1 \
           --jq 'sort_by(.createdAt) | reverse | .[0].number')
-        echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
+        echo "PR_NUMBER=${PR_NUMBER}" >> $GITHUB_ENV
       env:
         GH_TOKEN: ${{ inputs.GITHUB_TOKEN }}
 
     - name: Enable PR automerge
       shell: ${{ env.shell }}
       run: |
-        gh pr merge ${PR_NUMBER} --auto
+        gh pr merge ${PR_NUMBER} \
+          --squash \
+          --auto
       env:
         GH_TOKEN: ${{ inputs.GITHUB_TOKEN }}
 

--- a/.github/actions/backport/action.yml
+++ b/.github/actions/backport/action.yml
@@ -71,15 +71,6 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.GITHUB_TOKEN }}
 
-    - name: Report success
-      shell: ${{ env.shell }}
-      run: |
-        gh pr comment "${{ github.event.pull_request.number }}" \
-          --repo ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} \
-          --body "👍 Created $(gh pr view --json url --jq .url) to backport into [\`${{ inputs.TARGET_BRANCH }}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tree/${{ inputs.TARGET_BRANCH }})."
-      env:
-        GH_TOKEN: ${{ inputs.GITHUB_TOKEN }}
-
     - name: Report errors
       shell: ${{ env.shell }}
       if: failure() && steps.assert-branch-exists.outputs.failure-already-reported != 'true'

--- a/.github/actions/backport/action.yml
+++ b/.github/actions/backport/action.yml
@@ -62,25 +62,10 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.GITHUB_TOKEN }}
 
-    - name: Get new PR number
-      shell: ${{ env.shell }}
-      run: |
-        # GitHub has no out-of-the-box way to get the PR number when the PR is raised - instead, use the most recently-raised PR
-        # https://stackoverflow.com/a/76124312
-        PR_NUMBER=$(gh pr list \
-          --state open \
-          --base ${{ inputs.TARGET_BRANCH }} \
-          --json number,createdAt \
-          --limit 1 \
-          --jq 'sort_by(.createdAt) | reverse | .[0].number')
-        echo "PR_NUMBER=${PR_NUMBER}" >> $GITHUB_ENV
-      env:
-        GH_TOKEN: ${{ inputs.GITHUB_TOKEN }}
-
     - name: Enable PR automerge
       shell: ${{ env.shell }}
       run: |
-        gh pr merge ${PR_NUMBER} \
+        gh pr merge \
           --squash \
           --auto
       env:
@@ -90,8 +75,8 @@ runs:
       shell: ${{ env.shell }}
       run: |
         gh pr comment "${{ github.event.pull_request.number }}" \
-          --repo $GITHUB_SERVER_URL/$GITHUB_REPOSITORY \
-          --body "👍 Created ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${PR_NUMBER} to backport into [\`${{ inputs.TARGET_BRANCH }}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tree/${{ inputs.TARGET_BRANCH }})."
+          --repo ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} \
+          --body "👍 Created $(gh pr view --json url  --jq .url) to backport into [\`${{ inputs.TARGET_BRANCH }}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tree/${{ inputs.TARGET_BRANCH }})."
       env:
         GH_TOKEN: ${{ inputs.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Backport PRs are raised (at least, when through the GitHub Action) [via a bot account (`github-actions[bot]`) rather than the original PR author](https://github.com/hazelcast/hz-docs/pull/1486). It's easy for the original author to miss that they must merge this PR as it won't appear on [their list of authored PRs](https://github.com/search?q=is%3Aopen+author%3A%40me&type=pullrequests&s=created&o=asc).

Specifically, this was raised from feedback in `hz-docs` - one PR could be backported to several versions, and in _each_ PR a `CODEOWNER` must review and _someone_ must merge the PR - this PR removes the explicit requirement to merge. I don't see a scenario where someone would raise a backport PR without the intention of merging it _when possible_.

Tested [here](https://github.com/JackPGreen/backport-test/pull/121#issuecomment-2604625633).

Fixes: https://github.com/hazelcast/backport/issues/19