### PR TITLE
Fix Backport action

### DIFF
--- a/.github/actions/backport/action.yml
+++ b/.github/actions/backport/action.yml
@@ -69,7 +69,7 @@ runs:
           --repo ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} \
           --body "👍 Created $(gh pr view --json url --jq .url) to backport into [\`${{ inputs.TARGET_BRANCH }}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tree/${{ inputs.TARGET_BRANCH }})."
       env:
-        GH_TOKEN: ${{ inputs.GITHUB_TOKEN }
+        GH_TOKEN: ${{ inputs.GITHUB_TOKEN }}
 
     - name: Report errors
       shell: ${{ env.shell }}


### PR DESCRIPTION
A [syntax error causes a failure to evaluate the script](https://github.com/hazelcast/hz-docs/actions/runs/12912238050).

This was _probably_ a copy-paste error introduced when copying from my test environment in https://github.com/hazelcast/backport/pull/21.

I have investigated some kind of validation tool to catch this error to add to the PR builder without running the workflow but been unsuccessful.