### PR TITLE
Fix `backport` PR comments

### DIFF
--- a/.github/actions/backport/action.yml
+++ b/.github/actions/backport/action.yml
@@ -5,9 +5,6 @@ name: Backport
 inputs:
   GITHUB_TOKEN:
     required: true
-  PULL_REQUEST_NUMBER:
-    description: The PR number of the source PR, where success/failure comments will be added
-    required: true
   TARGET_BRANCH:
     description: The branch in the repository to backport changes into
     required: true
@@ -34,7 +31,7 @@ runs:
           echo "::debug::Branch ${{ inputs.TARGET_BRANCH }} exists"
         else
           echo "::error::Branch ${{ inputs.TARGET_BRANCH }} does not exist"
-          gh pr comment "${{ inputs.PULL_REQUEST_NUMBER }}" \
+          gh pr comment "${{ github.event.number }}" \
             --repo ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} \
             --body "❌ The backport branch \`${{ inputs.TARGET_BRANCH }}\` doesn't exist."
           echo "failure-already-reported=true" >> ${GITHUB_OUTPUT}
@@ -68,7 +65,7 @@ runs:
     - name: Report success
       shell: ${{ env.shell }}
       run: |
-        gh pr comment "${{ inputs.PULL_REQUEST_NUMBER }}" \
+        gh pr comment "${{ github.event.number }}" \
           --repo ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} \
           --body "👍 Created $(gh pr view --json url --jq .url) to backport into [\`${{ inputs.TARGET_BRANCH }}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tree/${{ inputs.TARGET_BRANCH }})."
       env:
@@ -92,7 +89,7 @@ runs:
         echo "        * Enable \"Send write tokens to workflows from fork pull requests\""
         echo "        * Use a different \"GITHUB_TOKEN\" with appropriate permissions"
         echo "::endgroup::"
-        gh pr comment "${{ inputs.PULL_REQUEST_NUMBER }}" \
+        gh pr comment "${{ github.event.number }}" \
           --repo ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} \
           --body "❌ [Failed to backport](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}), change must be manually backported."
       env:

--- a/.github/actions/backport/action.yml
+++ b/.github/actions/backport/action.yml
@@ -5,6 +5,9 @@ name: Backport
 inputs:
   GITHUB_TOKEN:
     required: true
+  PULL_REQUEST_NUMBER:
+    description: The PR number of the source PR, where success/failure comments will be added
+    required: true
   TARGET_BRANCH:
     description: The branch in the repository to backport changes into
     required: true
@@ -31,7 +34,7 @@ runs:
           echo "::debug::Branch ${{ inputs.TARGET_BRANCH }} exists"
         else
           echo "::error::Branch ${{ inputs.TARGET_BRANCH }} does not exist"
-          gh pr comment "${{ github.event.pull_request.number }}" \
+          gh pr comment "${{ inputs.PULL_REQUEST_NUMBER }}" \
             --repo ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} \
             --body "❌ The backport branch \`${{ inputs.TARGET_BRANCH }}\` doesn't exist."
           echo "failure-already-reported=true" >> ${GITHUB_OUTPUT}
@@ -65,7 +68,7 @@ runs:
     - name: Report success
       shell: ${{ env.shell }}
       run: |
-        gh pr comment "${{ github.event.pull_request.number }}" \
+        gh pr comment "${{ inputs.PULL_REQUEST_NUMBER }}" \
           --repo ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} \
           --body "👍 Created $(gh pr view --json url --jq .url) to backport into [\`${{ inputs.TARGET_BRANCH }}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tree/${{ inputs.TARGET_BRANCH }})."
       env:
@@ -89,7 +92,7 @@ runs:
         echo "        * Enable \"Send write tokens to workflows from fork pull requests\""
         echo "        * Use a different \"GITHUB_TOKEN\" with appropriate permissions"
         echo "::endgroup::"
-        gh pr comment "${{ github.event.pull_request.number }}" \
+        gh pr comment "${{ inputs.PULL_REQUEST_NUMBER }}" \
           --repo ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} \
           --body "❌ [Failed to backport](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}), change must be manually backported."
       env:


### PR DESCRIPTION
Because the original PR number isn't available, we end up putting comments on the new backported PR instead when we meant to comment on the source.

[Example](https://github.com/hazelcast/hz-docs/actions/runs/13028548879/job/36342475892):
```
gh pr comment "" \
   --repo ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} \
   --body "👍 Created $(gh pr view --json url --jq .url) to backport into [\`v/5.3\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tree/v/5.3)."
```


[Example](https://github.com/hazelcast/hz-docs/pull/1505#issuecomment-2621143566):
<img width="934" alt="image" src="https://github.com/user-attachments/assets/4de6c363-5346-4ac1-af84-9b065946cdf3" />

This should've gone on the [source PR](https://github.com/hazelcast/hz-docs/pull/1501).

Tested here ([source](https://github.com/JackPGreen/backport-test/pull/132) + [backported PRs](https://github.com/JackPGreen/backport-test/pull/133)).