### PR TITLE
Fix source PR identification for `push` events

### DIFF
--- a/.github/actions/backport/action.yml
+++ b/.github/actions/backport/action.yml
@@ -27,8 +27,10 @@ runs:
       shell: ${{ env.shell }}
       run: |
         if [ -n "${{ github.event.number }}" ]; then
+          # pull request events include the source PR number
           echo "SOURCE_PR_NUMBER=${{ github.event.number }}" >> ${GITHUB_ENV}
         else
+          # push events do not so must find the PR associated with the commit
           echo "SOURCE_PR_NUMBER=$(gh api repos/${{ github.repository }}/commits/${{ github.sha }}/pulls --jq '.[0].number')" >> ${GITHUB_ENV}
         fi
       env:

--- a/.github/actions/backport/action.yml
+++ b/.github/actions/backport/action.yml
@@ -23,6 +23,17 @@ env:
 runs:
   using: composite
   steps:
+    - name: Get source PR number
+      shell: ${{ env.shell }}
+      run: |
+        if [ -n "${{ github.event.number }}" ]; then
+          echo "SOURCE_PR_NUMBER=${{ github.event.number }}" >> ${GITHUB_ENV}
+        else
+          echo "SOURCE_PR_NUMBER=$(gh api repos/${{ github.repository }}/commits/${{ github.sha }}/pulls --jq '.[0].number')" >> ${GITHUB_ENV}
+        fi
+      env:
+        GH_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+
     - name: Assert branch exists
       id: assert-branch-exists
       shell: ${{ env.shell }}
@@ -31,7 +42,7 @@ runs:
           echo "::debug::Branch ${{ inputs.TARGET_BRANCH }} exists"
         else
           echo "::error::Branch ${{ inputs.TARGET_BRANCH }} does not exist"
-          gh pr comment "${{ github.event.number }}" \
+          gh pr comment "${SOURCE_PR_NUMBER}" \
             --repo ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} \
             --body "❌ The backport branch \`${{ inputs.TARGET_BRANCH }}\` doesn't exist."
           echo "failure-already-reported=true" >> ${GITHUB_OUTPUT}
@@ -65,7 +76,7 @@ runs:
     - name: Report success
       shell: ${{ env.shell }}
       run: |
-        gh pr comment "${{ github.event.number }}" \
+        gh pr comment "${SOURCE_PR_NUMBER}" \
           --repo ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} \
           --body "👍 Created $(gh pr view --json url --jq .url) to backport into [\`${{ inputs.TARGET_BRANCH }}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tree/${{ inputs.TARGET_BRANCH }})."
       env:
@@ -89,7 +100,7 @@ runs:
         echo "        * Enable \"Send write tokens to workflows from fork pull requests\""
         echo "        * Use a different \"GITHUB_TOKEN\" with appropriate permissions"
         echo "::endgroup::"
-        gh pr comment "${{ github.event.number }}" \
+        gh pr comment "${SOURCE_PR_NUMBER}" \
           --repo ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} \
           --body "❌ [Failed to backport](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}), change must be manually backported."
       env:


### PR DESCRIPTION
`github.event.number` is only populated for actions triggered by pull request `event`s, not `push` etc. As we use this to tell `gh` on which PR to put the comments, when it's empty `gh` simply uses the new backported PR as a fallback.

GitHub doesn't give the action the source PR on a `push` event, but [we can use the GitHub API to query the PR of the commit that was `push`ed to figure it out](https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#list-pull-requests-associated-with-a-commit), and instead use that in those cases.

Testing:
- [PR backported by label added post-merge (e.g. `hazelcast-mono`)](https://github.com/JackPGreen/backport-test/pull/137)
- [PR backported by `push` trigger (e.g. `hz-docs`)](https://github.com/JackPGreen/backport-test/pull/139)

Fixes: https://github.com/hazelcast/backport/issues/25, [Slack discussion](https://hazelcast.slack.com/archives/C07066ELRRD/p1743505394712119)