### PR TITLE
Refactor how `assert.sh` is downloaded for tests

### DIFF
--- a/backport.functions_tests
+++ b/backport.functions_tests
@@ -5,13 +5,8 @@ SCRIPT_DIR=$(readlink -f "$0")
 SCRIPT_DIR="$(dirname "${SCRIPT_DIR}")"
 
 # Source the latest version of assert.sh unit testing library and include in current shell
-curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh --output assert.sh
+source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 
-# shellcheck source=/dev/null
-# You _should_ be able to avoid a temporary file with something like
-# . <(echo "${assert_script_content}")
-# But this doesn't work on the MacOS GitHub runner (but does on MacOS locally)
-. assert.sh
 # shellcheck source=/dev/null
 . "${SCRIPT_DIR}"/backport.functions
 

--- a/backport_tests
+++ b/backport_tests
@@ -5,15 +5,7 @@ SCRIPT_DIR=$(readlink -f "$0")
 SCRIPT_DIR="$(dirname "${SCRIPT_DIR}")"
 
 # Source the latest version of assert.sh unit testing library and include in current shell
-curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh --output assert.sh
-
-# shellcheck source=/dev/null
-# You _should_ be able to avoid a temporary file with something like
-# . <(echo "${assert_script_content}")
-# But this doesn't work on the MacOS GitHub runner (but does on MacOS locally)
-. assert.sh
-# shellcheck source=/dev/null
-# . "${SCRIPT_DIR}"/backport
+source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 
 TESTS_RESULT=0
 


### PR DESCRIPTION
We can simplify as discussed [here](https://github.com/hazelcast/docker-actions/pull/1#discussion_r2149451062).