### PR TITLE
Retain Jira references in backport titles

### DIFF
--- a/backport
+++ b/backport
@@ -115,7 +115,7 @@ log_info "Backporting the last commit from $SOURCE onto $TARGET"
 
 COMMIT_MSG=$(git show -s --format='%s' "$SOURCE")
 ORIGINAL_PR_NUMBER=$(get_pr_number "$COMMIT_MSG")
-NEW_COMMIT_MSG="$( echo "${COMMIT_MSG// \(\#$ORIGINAL_PR_NUMBER\)}" | sed -r 's/ \[.+\]//g') [$SUFFIX]"
+NEW_COMMIT_MSG="$( echo "${COMMIT_MSG// \(\#$ORIGINAL_PR_NUMBER\)}" | sed -r 's/ \[[^]-]+\]//g') [$SUFFIX]"
 UPSTREAM_URL="$(git remote get-url upstream)"
 if [[ $UPSTREAM_URL == http* ]]; then
   REPO_UPSTREAM="$(echo $UPSTREAM_URL | awk -F'/' '{print $4"/"$5}' | cut -d. -f1)"


### PR DESCRIPTION
The script removes any previous suffixes when computing new commit title (e.g. when backporting `blah [5.5.z]` to `5.4.z`, the `5.5.z` references should be removed. But this check is too fuzzy and `[anything]` is removed - which is a problem when Jira references are used (and subsequently, removed).

It's not possible to know what format the previous suffix _might've_ been (it could be any valid branch name), but to workaround this _specific_ issue we can check it doesn't contain a `-` - in our typical use-case, this is enough to differentiate a branch from a Jira issue reference.

Fixes: [DI-616](https://hazelcast.atlassian.net/browse/DI-616)