### PR TITLE
Update token supplied to `8BitJonny/gh-get-current-pr` to support forked-PR execution

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -30,7 +30,7 @@ jobs:
       - id: pr
         uses: 8BitJonny/gh-get-current-pr@4056877062a1f3b624d5d4c2bedefa9cf51435c9 # v4.0.0
         with:
-          # Authetication token to access GitHub APIs. (Can be omitted by default.)
+          # Required to support forked execution
           github-token: ${{ secrets.GH_TOKEN }}
 
   parse-pr:


### PR DESCRIPTION
Despite _extensive_ testing for https://github.com/hazelcast/backport/pull/31, [the action fails with a cryptic `Not Found` when executed for real](https://github.com/hazelcast/hazelcast-mono/actions/runs/20035261330).

After further investigation, this could be reproduced [within a PR from a fork _only_](https://github.com/JackPGreen/backport-test/actions/runs/20035612426/job/57456162344), which was not previously tested.

The root cause is that the "implicit" token supplied to the workflow does not have permissions to query metadata [_outside of the repo it's being run from_](https://github.com/orgs/community/discussions/46566). Instead, we should use the supplied token that we already use for the "main" backporting operation.

[Successful execution from a forked PR](https://github.com/JackPGreen/backport-test/actions/runs/20035695929/job/57456466025), and [resultant backport](https://github.com/JackPGreen/backport-test/pull/221).