### PR TITLE
Re-implement `get-current-pr` action, add authentication.

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -45,7 +45,7 @@ jobs:
           max_iterations=10
           iteration=0
 
-          while (( iteration < max_iterations )); do
+          while [[ ${iteration} -le ${max_iterations} ]]; do
             response=$(gh api \
               -H "Accept: application/vnd.github+json" \
               /repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls)
@@ -56,7 +56,7 @@ jobs:
               break
             else
               echo "API returned no results, retrying..."
-              ((iteration++))
+              iteration=$((iteration + 1))
               sleep 1
             fi
           done


### PR DESCRIPTION
Despite _extensive_ testing for https://github.com/hazelcast/backport/pull/31, [the action fails with a cryptic `Not Found` when executed for real](https://github.com/hazelcast/hazelcast-mono/actions/runs/20035261330).

After further investigation, this could be reproduced [within a PR from a fork _only_](https://github.com/JackPGreen/backport-test/actions/runs/20035612426/job/57456162344), which was not previously tested.

The root cause is that the "implicit" token supplied to the workflow does not have permissions to query metadata [_outside of the repo it's being run from_](https://github.com/orgs/community/discussions/46566). Instead, we should use the supplied token that we already use for the "main" backporting operation.

After discussion as part of https://github.com/hazelcast/backport/pull/32, it was also suggested to avoid using the token with a third-party action when a first-party solution was available (with some mangling).

Changes:
- add token to `get-current-pr` step
- replace `8BitJonny/gh-get-current-pr` with our own implementation
- fix a syntax error when creating backport branches

[Successful execution from a forked PR](https://github.com/JackPGreen/backport-test/actions/runs/20098427088), and [resultant backport](https://github.com/JackPGreen/backport-test/pull/242).

Closes: https://github.com/hazelcast/backport/pull/32

