### PR TITLE
Replace explicit token input with implicit `GITHUB_TOKEN` [DI-690]

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -12,9 +12,6 @@ on:
         description: Additional options to pass through to the tool
         required: false
         type: string
-    secrets:
-      GH_TOKEN:
-        required: true
 
 jobs:
   get-current-pr:
@@ -44,7 +41,7 @@ jobs:
           echo "labels=$(jq --raw-output --compact-output '.[0].labels | map(.name)' <<< "${response}")" >> ${GITHUB_ENV}
           echo "merge_commit_sha=${GITHUB_SHA}" >> ${GITHUB_ENV}
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
 
   parse-pr:
     if: needs.get-current-pr.outputs.merge_commit_sha != ''
@@ -103,7 +100,7 @@ jobs:
               --remove-label "${backport_label}"
           done
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
 
   backport:
     name: Backport to "${{ matrix.branch }}"
@@ -121,7 +118,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ matrix.branch }}
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ github.token }}
 
       - name: 'Checkout `hazelcast/backport`'
         uses: actions/checkout@v4
@@ -152,7 +149,7 @@ jobs:
             --non-interactive \
             ${{ inputs.BACKPORT_OPTIONS }}
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
 
       - name: Report success
         run: |
@@ -162,7 +159,7 @@ jobs:
             --repo ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} \
             --body "👍 Created $(gh pr view --json url --jq .url) to backport into [\`${{ matrix.branch }}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tree/${{ matrix.branch }})."
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
 
       - name: Report errors
         if: failure()
@@ -188,4 +185,4 @@ jobs:
             --repo ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} \
             --body "❌ [Failed to backport](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}), change must be manually backported."
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -21,14 +21,30 @@ jobs:
     name: Get current PR
     runs-on: ubuntu-slim
     outputs:
-      number: ${{ steps.pr.outputs.number }}
+      number: ${{ env.number }}
       # Extract as much metadata as possible to avoid querying later
-      labels: ${{ steps.pr.outputs.pr_labels }}
-      # The action returns a SHA even for unmerged PRs, additional filtering required
-      merge_commit_sha: ${{ steps.pr.outputs.pr_found == 'true' && fromJSON(steps.pr.outputs.pr).merged_at != null && fromJSON(steps.pr.outputs.pr).merge_commit_sha || '' }}
+      labels: ${{ env.labels }}
+      merge_commit_sha: ${{ env.merge_commit_sha }}
     steps:
-      - id: pr
-        uses: 8BitJonny/gh-get-current-pr@4056877062a1f3b624d5d4c2bedefa9cf51435c9 # v4.0.0
+      - name: Extract PR metadata from merged 'pull_request' event
+        if: github.event.pull_request.merged && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target')
+        run: |
+          echo "number=${{ github.event.number }}" >> ${GITHUB_ENV}
+          echo "labels=$(jq --compact-output '[.[] | .name]' <<< '${{ toJson(github.event.pull_request.labels) }}')" >> ${GITHUB_ENV}
+          echo "merge_commit_sha=${{ github.event.pull_request.merge_commit_sha }}" >> ${GITHUB_ENV}
+
+      - name: Extract PR metadata from 'push' event
+        if: github.event_name == 'push'
+        run: |
+          response=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            /repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls)
+
+          echo "number=$(jq --raw-output '.[0].number' <<< "${response}")" >> ${GITHUB_ENV}
+          echo "labels=$(jq --raw-output --compact-output '.[0].labels | map(.name)' <<< "${response}")" >> ${GITHUB_ENV}
+          echo "merge_commit_sha=${GITHUB_SHA}" >> ${GITHUB_ENV}
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
   parse-pr:
     if: needs.get-current-pr.outputs.merge_commit_sha != ''
@@ -50,9 +66,7 @@ jobs:
           backport_labels=()
           backport_branches=()
 
-          IFS=, read -ra labels <<< "${{ needs.get-current-pr.outputs.labels }}"
-
-          for label in "${labels[@]}"; do
+          while IFS= read -r label; do
             if [[ ${label} == "${BACKPORT_PREFIX}"* ]]; then
               backport_labels+=("${label}")
 
@@ -62,25 +76,26 @@ jobs:
             else
               echodebug "Skipped label \"${label}\" (not a backport)"
             fi
-          done
+          done < <(jq --raw-output '.[]' <<< '${{ needs.get-current-pr.outputs.labels }}')
 
           function array_to_json() {
             jq --null-input --compact-output '$ARGS.positional' --args "$@"
           }
 
           json=$(array_to_json "${backport_labels[@]}")
-          echo "backport_labels=${json})" >> ${GITHUB_OUTPUT}
+          echo "backport_labels=${json}" >> ${GITHUB_OUTPUT}
 
           json=$(array_to_json "${backport_branches[@]}")
-          echo "backport_branches=${json})" >> ${GITHUB_OUTPUT}
+          echo "backport_branches=${json}" >> ${GITHUB_OUTPUT}
         env:
           BACKPORT_PREFIX: ${{ inputs.BACKPORT_PREFIX }}
 
       - name: Remove backport labels (${{ steps.parse-labels.outputs.backport_labels }})
+        if: steps.parse-labels.outputs.backport_labels != '[]'
         run: |
           set -o errexit -o nounset -o pipefail ${RUNNER_DEBUG:+-x}
 
-          mapfile -t labels < <(jq -r '.[]' <<< '${{ steps.parse-labels.outputs.backport_labels }}')
+          mapfile -t labels < <(jq --raw-output '.[]' <<< '${{ steps.parse-labels.outputs.backport_labels }}')
 
           for backport_label in "${labels[@]}"; do
             gh pr edit "${{ needs.get-current-pr.outputs.number }}" \


### PR DESCRIPTION
The action _currently_ requires a token input, which means a typical implementation uses a long-lived PAT:
https://github.com/hazelcast/hz-docs/blob/b01fcb2b18c8cd4eb87dc901ca6972ad9832f1a9/.github/workflows/backport-workflow.yml#L37-L39, and requires `pull_request_target` execution for that secret to be accessible.

Instead, we should use the default `GITHUB_TOKEN` to avoid this.

[Example execution](https://github.com/JackPGreen/backport-test/actions/runs/20079427303/job/57602442631) and [resultant PR](https://github.com/JackPGreen/backport-test/pull/238) - note now it's not using [`devOpsHazelcast`](https://github.com/devOpsHazelcast)'s token, PRs will instead by `github-actions[bot]`.

Fixes: [DI-690](https://hazelcast.atlassian.net/browse/DI-690)

Post-merge actions:
- [x] update _every_ reference (...including maintenance branches...) as per https://github.com/hazelcast/hazelcast-mono/pull/5723

[DI-690]: https://hazelcast.atlassian.net/browse/DI-690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ