### PR TITLE
Allow _optional_ token to be provided

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -12,6 +12,10 @@ on:
         description: Additional options to pass through to the tool
         required: false
         type: string
+      PR_CREATE_TOKEN:
+        description: Optional token used for PR creation, defaults to github.token - using a "real" token allows for downstream actions to be triggered - https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#triggering-a-workflow-from-a-workflow
+        required: false
+        type: string
 
 jobs:
   get-current-pr:
@@ -194,7 +198,7 @@ jobs:
             --non-interactive \
             ${{ inputs.BACKPORT_OPTIONS }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ inputs.PR_CREATE_TOKEN || github.token }}
 
       - name: Report success
         if: steps.check-backport-branch-already-exists.outputs.exists == 'false'


### PR DESCRIPTION
When the `github.token` is used to create the backport, any subsequent action (e.g. one triggered on a new PR) is skipped due to [GitHub workflow triggering rules](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#triggering-a-workflow-from-a-workflow).

To workaround this, we should allow the _option_ to provide a non-bot token so GitHub thinks the PR is raised by a "real" user.

[Slack discussion](https://hazelcast.slack.com/archives/C07066ELRRD/p1776075815539339)

[Example execution (without token to prove it doesn't break existing)](https://github.com/JackPGreen/backport-test/actions/runs/24343664366/job/71078671219).