### PR TITLE
Make `PR_CREATE_TOKEN` a `secret`

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -12,10 +12,10 @@ on:
         description: Additional options to pass through to the tool
         required: false
         type: string
+    secrets:
       PR_CREATE_TOKEN:
         description: Optional token used for PR creation, defaults to github.token - using a "real" token allows for downstream actions to be triggered - https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#triggering-a-workflow-from-a-workflow
         required: false
-        type: string
 
 jobs:
   get-current-pr:
@@ -198,7 +198,7 @@ jobs:
             --non-interactive \
             ${{ inputs.BACKPORT_OPTIONS }}
         env:
-          GH_TOKEN: ${{ inputs.PR_CREATE_TOKEN || github.token }}
+          GH_TOKEN: ${{ secrets.PR_CREATE_TOKEN || github.token }}
 
       - name: Report success
         if: steps.check-backport-branch-already-exists.outputs.exists == 'false'


### PR DESCRIPTION
In https://github.com/hazelcast/backport/pull/40, a token `input` added - although it _technically works_, GitHub prevents you from actually passing in a `secret` when you want to _use_ it, so in practice it's useless:
<img width="482" height="572" alt="image" src="https://github.com/user-attachments/assets/94907788-30fb-4a81-996e-5ea8bae92ce4" />

Updated to correctly define it as a `secret`.

Example execution:
- [with a valid token showing it actually works](https://github.com/JackPGreen/backport-test/actions/runs/24395038764/job/71250635521)
- [with an invalid token showing it is actually using the token because it fails to authenticate](https://github.com/JackPGreen/backport-test/actions/runs/24395135078)