### PR TITLE
Prevent overlapping action executions by querying live PR labels

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -23,8 +23,6 @@ jobs:
     runs-on: ubuntu-slim
     outputs:
       number: ${{ env.number }}
-      # Extract as much metadata as possible to avoid querying later
-      labels: ${{ env.labels }}
       merge_commit_sha: ${{ env.merge_commit_sha }}
     steps:
       - name: Extract PR metadata from merged 'pull_request' event
@@ -32,7 +30,6 @@ jobs:
         run: |
           # If the action was triggered by labelling a PR, we can simply pull the PR metadata directly from the event
           echo "number=${{ github.event.number }}" >> ${GITHUB_ENV}
-          echo "labels=$(jq --compact-output '[.[] | .name]' <<< '${{ toJson(github.event.pull_request.labels) }}')" >> ${GITHUB_ENV}
           echo "merge_commit_sha=${{ github.event.pull_request.merge_commit_sha }}" >> ${GITHUB_ENV}
 
       - name: Extract PR metadata from 'push' event
@@ -63,7 +60,6 @@ jobs:
           done
 
           echo "number=$(jq --raw-output '.[0].number' <<< "${response}")" >> ${GITHUB_ENV}
-          echo "labels=$(jq --raw-output --compact-output '.[0].labels | map(.name)' <<< "${response}")" >> ${GITHUB_ENV}
           echo "merge_commit_sha=${GITHUB_SHA}" >> ${GITHUB_ENV}
         env:
           GH_TOKEN: ${{ github.token }}
@@ -88,6 +84,8 @@ jobs:
           backport_labels=()
           backport_branches=()
 
+          # Iterate through PR labels
+          # Query via API (inside of `concurrent` block) to ensure we have the latest labels - in case another execution updated any labels while the workflow was being executed
           while IFS= read -r label; do
             if [[ ${label} == "${BACKPORT_PREFIX}"* ]]; then
               backport_labels+=("${label}")
@@ -98,7 +96,10 @@ jobs:
             else
               echodebug "Skipped label \"${label}\" (not a backport)"
             fi
-          done < <(jq --raw-output '.[]' <<< '${{ needs.get-current-pr.outputs.labels }}')
+          done < <(gh api \
+              -H "Accept: application/vnd.github+json" \
+              /repos/${GITHUB_REPOSITORY}/pulls/${{ needs.get-current-pr.outputs.number }} \
+              --jq '.labels.[].name')
 
           function array_to_json() {
             jq --null-input --compact-output '$ARGS.positional' --args "$@"
@@ -110,6 +111,7 @@ jobs:
           json=$(array_to_json "${backport_branches[@]}")
           echo "backport_branches=${json}" >> ${GITHUB_OUTPUT}
         env:
+          GH_TOKEN: ${{ github.token }}
           BACKPORT_PREFIX: ${{ inputs.BACKPORT_PREFIX }}
 
       - name: Remove backport labels (${{ steps.parse-labels.outputs.backport_labels }})


### PR DESCRIPTION
The action does not support re-execution - the intermediate backport branches name is not unique to each execution, which means if run multiple times for the same PR, when pushing the freshly-created branch it [instead fails with a conflict against the pre-existing branch](https://github.com/hazelcast/hazelcast-mono/actions/runs/26764731131/job/78887942359#step:5:337).

This is annoying but inconsequential - there's no requirement to execute _for the same backport_ simultaneously, and within the action we have some concurrency control to prevent parallel executions: https://github.com/hazelcast/backport/blob/c53c407f77b711c261a52868f3d37f0eff907d3a/.github/workflows/backport.yml#L77-L78

These parallel executions happen through the label triggering mechanism - when adding `n` labels to a PR (even if done in a single action), `n` `pull_request: labeled` events are triggered, one for _each_ new label.

The `parse-pr` job determines the branches (from the labels) to backport to, and then removes the labels once those backport executions are queued. By wrapping this in a `concurrency` block, the _idea_ was that only one execution could be converting labels -> backport executions at the same time - i.e. one label would _at most_ become one backport execution.

The problem is that while labels are removed from the PR by `parse-pr`, the value in `github.event.pull_request.labels` on the concurrent jobs is _when the job were triggered_, which means even though a label has been removed from the PR, some executions of the workflow will proceed with the (since removed) label and try to backport it again.

Worked example:
- user adds labels `5.5` & `5.6`
- GitHub triggers `backport` action execution (`execution#a`) with PR context including labels `[5.5, 5.6]`
- GitHub triggers `backport` action execution (`execution#b`) with PR context including labels `[5.5, 5.6]`
- `execution#a` hits the `concurrent` block, grabbing the lock
- `execution#b` hits the `concurrent` block, waits to be unblocked
- `execution#a`:
   - parses the labels
   - triggers backports to `5.5` & `5.6`
   - removes labels `5.5` & `5.6`
- `execution#b` is now unblocked, and proceeds to parse labels `5.5` & `5.6` despite those no longer existing on the PR
- `execution#a` backports successfully
- `execution#b` backports fail due to branch conflicts

The fix is simple - _always_ query the latest, live labels via the API inside the `concurrent` block.

Testing:
- [created a backport, added two labels](https://github.com/JackPGreen/backport-test/pull/285)
- [first execution worked normally](https://github.com/JackPGreen/backport-test/actions/runs/26827995929)
   - note for testing I disabled backports and just polled forever to allow parallel executions, hence failure
- [second execution waited for completion, and then identified no backports were required, skipping](https://github.com/JackPGreen/backport-test/actions/runs/26827993573/)