### PR TITLE
Ensure `fail` option used with curl to catch errors

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Extract PR metadata from 'push' event
         if: github.event_name == 'push'
         run: |
-          source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"
+          source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"
 
           # If the action was triggered by a commit being pushed, we must resolve the PR metadata via the GitHub API
 
@@ -79,7 +79,7 @@ jobs:
         id: parse-labels
         run: |
           set -o errexit -o nounset -o pipefail ${RUNNER_DEBUG:+-x}
-          source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"
+          source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"
 
           backport_labels=()
           backport_branches=()
@@ -160,7 +160,7 @@ jobs:
         id: check-backport-branch-already-exists
         run: |
           set -o errexit -o nounset -o pipefail ${RUNNER_DEBUG:+-x}
-          source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"
+          source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"
 
           source backport/backport.functions
 
@@ -183,7 +183,7 @@ jobs:
         if: steps.check-backport-branch-already-exists.outputs.exists == 'false'
         run: |
           set -o errexit -o nounset -o pipefail ${RUNNER_DEBUG:+-x}
-          source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"
+          source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"
 
           # Git metadata is required but not available out-of-the-box, inherit from the action
           git config user.name "${GITHUB_ACTOR}"
@@ -219,7 +219,7 @@ jobs:
         if: failure()
         run: |
           set -o errexit -o nounset -o pipefail ${RUNNER_DEBUG:+-x}
-          source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"
+          source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"
 
           echoerr "Error running action"
           echo_group "Troubleshooting Information:"

--- a/backport.functions_tests
+++ b/backport.functions_tests
@@ -5,7 +5,7 @@ SCRIPT_DIR=$(readlink -f "$0")
 SCRIPT_DIR="$(dirname "${SCRIPT_DIR}")"
 
 # Source the latest version of assert.sh unit testing library and include in current shell
-source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
+source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 
 # shellcheck source=/dev/null
 . "${SCRIPT_DIR}"/backport.functions

--- a/backport_tests
+++ b/backport_tests
@@ -5,7 +5,7 @@ SCRIPT_DIR=$(readlink -f "$0")
 SCRIPT_DIR="$(dirname "${SCRIPT_DIR}")"
 
 # Source the latest version of assert.sh unit testing library and include in current shell
-source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
+source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 
 TESTS_RESULT=0
 


### PR DESCRIPTION
By default, curl returns a `0` exit code even in the case of 404 errors.

This means that errors like the one in https://github.com/hazelcast/hazelcast-mono/pull/7091 are tricky to spot. It would be better if we used the [`fail` option](https://curl.se/docs/manpage.html#--fail) to ensure the failure is visible.