### PR TITLE
Harden `curl` usage - add retries and error logging

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Extract PR metadata from 'push' event
         if: github.event_name == 'push'
         run: |
-          source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"
+          source /dev/stdin <<< "$(curl --fail --retry 5 --retry-all-errors --show-error --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"
 
           # If the action was triggered by a commit being pushed, we must resolve the PR metadata via the GitHub API
 
@@ -79,7 +79,7 @@ jobs:
         id: parse-labels
         run: |
           set -o errexit -o nounset -o pipefail ${RUNNER_DEBUG:+-x}
-          source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"
+          source /dev/stdin <<< "$(curl --fail --retry 5 --retry-all-errors --show-error --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"
 
           backport_labels=()
           backport_branches=()
@@ -160,7 +160,7 @@ jobs:
         id: check-backport-branch-already-exists
         run: |
           set -o errexit -o nounset -o pipefail ${RUNNER_DEBUG:+-x}
-          source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"
+          source /dev/stdin <<< "$(curl --fail --retry 5 --retry-all-errors --show-error --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"
 
           source backport/backport.functions
 
@@ -183,7 +183,7 @@ jobs:
         if: steps.check-backport-branch-already-exists.outputs.exists == 'false'
         run: |
           set -o errexit -o nounset -o pipefail ${RUNNER_DEBUG:+-x}
-          source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"
+          source /dev/stdin <<< "$(curl --fail --retry 5 --retry-all-errors --show-error --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"
 
           # Git metadata is required but not available out-of-the-box, inherit from the action
           git config user.name "${GITHUB_ACTOR}"
@@ -219,7 +219,7 @@ jobs:
         if: failure()
         run: |
           set -o errexit -o nounset -o pipefail ${RUNNER_DEBUG:+-x}
-          source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"
+          source /dev/stdin <<< "$(curl --fail --retry 5 --retry-all-errors --show-error --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"
 
           echoerr "Error running action"
           echo_group "Troubleshooting Information:"

--- a/backport.functions_tests
+++ b/backport.functions_tests
@@ -5,7 +5,7 @@ SCRIPT_DIR=$(readlink -f "$0")
 SCRIPT_DIR="$(dirname "${SCRIPT_DIR}")"
 
 # Source the latest version of assert.sh unit testing library and include in current shell
-source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
+source /dev/stdin <<< "$(curl --fail --retry 5 --retry-all-errors --show-error --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 
 # shellcheck source=/dev/null
 . "${SCRIPT_DIR}"/backport.functions

--- a/backport_tests
+++ b/backport_tests
@@ -5,7 +5,7 @@ SCRIPT_DIR=$(readlink -f "$0")
 SCRIPT_DIR="$(dirname "${SCRIPT_DIR}")"
 
 # Source the latest version of assert.sh unit testing library and include in current shell
-source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
+source /dev/stdin <<< "$(curl --fail --retry 5 --retry-all-errors --show-error --silent https://raw.githubusercontent.com/hazelcast/assert.sh/main/assert.sh)"
 
 TESTS_RESULT=0
 


### PR DESCRIPTION
The change in https://github.com/hazelcast/hazelcast-docker/pull/1284 ensured failure was reported and the execution was halted, but the error message [wasn't clear](https://github.com/hazelcast/hazelcast-docker/actions/runs/28910263431/job/85765974279#step:6:31):
> Error: Process completed with exit code 22.

By adding the [`--show-error` option](https://curl.se/docs/manpage.html#--show-error) we can ensure the human readable error is printed to stderr, e.g.:
> curl: (56) The requested URL returned error: 404


In addition, the root cause of the failure is _probably_ an intermittent blip on the GitHub side ([related discussion](https://github.com/orgs/community/discussions/53538)) - so adding a simple retry-on-failure seems sensible.